### PR TITLE
apply single selection mode to the dictionary list on the preference window

### DIFF
--- a/src/main/java/io/github/cat_in_136/jadice/JaDicePreferencePane.kt
+++ b/src/main/java/io/github/cat_in_136/jadice/JaDicePreferencePane.kt
@@ -120,7 +120,7 @@ class JaDicePreferencePane(diceWorker: DiceWorker) : JPanel(BorderLayout()) {
 
             val scrollPane1 = JScrollPane()
             rootPane.add(scrollPane1, BorderLayout.CENTER)
-            dicListView.selectionMode = ListSelectionModel.SINGLE_INTERVAL_SELECTION
+            dicListView.selectionMode = ListSelectionModel.SINGLE_SELECTION
             dicListView.model = dicListModel
             dicListView.cellRenderer = object : DefaultListCellRenderer() {
                 override fun getListCellRendererComponent(list: JList<*>,


### PR DESCRIPTION
The dictionary list on the preference window is assumed to a single selection list in the action. The implementation allows to select multiple dictionaries (items) by Ctrl+Click, but it must be better to select only single one.